### PR TITLE
updated set of functions for parsing month strings

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,188 @@ from datetime import datetime
 from pathlib import Path
 
 
+def check_dels(month_error, typ_dict):
+    """
+    Checks a dictionary of single-letter deletions of the months for a match
+
+    Args:
+        month_error (str): the month string with a typo (long months,
+            e.g., "Novembe")
+        typo_dict (dict): dictionary with months for keys, values are lists
+            of all single-letter deletions for that month (key)
+
+    Returns:
+        returns the correct month string if a match is found, otherwise it
+            returns False
+    """
+    for k, v in typ_dict.items():
+        correct_month = False  # set return value for not finding a match
+        if month_error in v:  # if we find a match, return the correct month
+            return k
+
+
+def sliding_window(test, reference):
+    """
+    Uses a sliding window method to try to find the best match for a misspelled
+        month. Imagine a transparent reference window printed with the target
+        string on it. This window is slid across the test string and each
+        position is checked for how similar it is to the reference. This score
+        is used to determine the most likely "correct" substring in the test.
+        More detailed explanation here:
+            https://www.geeksforgeeks.org/window-sliding-technique/
+
+    Args:
+        test (str): the (potentially) misspelled string that needs correcting
+        reference (str): the target string we're comparing the test string to
+
+    Returns:
+        tuple(best_match, best_match_score)
+            best_match (str): methods best guess at what the correct month is
+            best_match_score (int): numeric score for how good the match is
+                higher is better, can be normalized to len(month)
+    """
+    best_score = 0
+    best_result = ''
+    ref_len = len(reference)
+    # padding the string to avoid out of bounds errors and allow head-to-tail
+    #  comparisons. For example:
+    # reference: 'june'  (move this string right one character at at ime)
+    # test:      '    une    '
+    test = (ref_len*' ') + test + (ref_len*' ')
+
+    for i in range(len(test)-ref_len):  # iterate through all indices
+        score = score_window(test[i:i+ref_len], reference)
+        if best_score < score:
+            best_score = score
+            best_result = test[i:i+ref_len]
+
+    return (best_result, best_score)
+
+
+def score_window(window, target):
+    """
+    Compare the data in the window to the target sequence
+        and compute a numeric score based on how similar it is
+
+    Args:
+        window (str): a substring of equal length to target, from the test
+            string in sliding_window
+        target (str): the sequence we're looking for
+    """
+    score = 0
+    if len(window) != len(target):
+        # print('unequal')
+        return -1  # unequal lengths don't work with this method
+    for i in range(len(window)):  # iterate letter-by-letter
+        if window[i] == target[i]:
+            score += 1  # matches increase score, higher scores are better
+    return score
+
+
+def check_misspells(word):
+    """
+    'Wrapper' function for sliding_window that compares a (potentially)
+        misspelled word (word) to each of the months to find the best match
+
+    Args:
+        word (str): the misspelled month string
+    Returns:
+        tuple(best_match, best_match_score)
+            best_match (str): methods best guess at what the correct month is
+            best_match_score (int): numeric score for how good the match is
+                higher is better, can be normalized to len(month)
+    """
+    months = [
+        'january',
+        'february',
+        'march',
+        'april',
+        'may',
+        'june',
+        'july',
+        'august',
+        'september',
+        'october',
+        'november',
+        'december']
+    best_score = 0
+    best_result = ''
+    for month in months:
+        if abs(len(month) - len(word)) > 1:
+            continue
+        result, score = sliding_window(word, month)
+        # print(result, score)
+        if score > best_score:
+            best_score = score
+            best_result = month
+    return (best_result, best_score)
+
+
+def make_typo_dict(word_list=[]):
+    """
+    Creates a dictionary with keys equal to word_list, with values being a 
+        list of every possible single-letter deletion of that word
+
+    Args:
+        word_list (list): a list of strings to make single deletions from. If
+            none is provided (i.e., an empty list) is uses the keys from the
+            month_dict below.
+    Returns:
+        typo_dict (dict): dictionary containing every possible single-letter
+            deletion of each of the keys in the dict    
+    """
+    month_dict = {'january': '01',
+                  'february': '02',
+                  'march': '03',
+                  'april': '04',
+                  'may': '05',
+                  'june': '06',
+                  'july': '07',
+                  'august': '08',
+                  'september': '09',
+                  'october': '10',
+                  'november': '11',
+                  'december': '12'
+                }
+    if len(word_list) == 0:
+        word_list = month_dict.keys()
+
+    # this creates a dictionary containing all possible single-letter deletions of every month
+    # it's used to correct for typos in the text of a link to the minutes
+    # ex: Novembe 17, 2010 (one of two real examples as of Aug 9, 2020)
+    typo_dict = {k: list() for k in word_list}
+    for month in typo_dict.keys():
+        for i in range(len(month)):
+            typo_dict[month].append(month[:i] + month[i+1:])
+    
+    return typo_dict
+
+
+def pick_best_month(word, typ_dict=make_typo_dict()):
+    """
+    'Wrapper' function for various spell-checking methods. Check deletions
+        first to avoid known errors with deletions and sliding_window.
+
+    Args:
+        word (str): the misspelled month string
+        typo_dict (dict): dictionary with months for keys, values are lists
+            of all single-letter deletions for that month (key)
+
+    Returns:
+        tuple(best_match, best_match_score)
+            best_match (str): methods best guess at what the correct month is
+            best_match_score (int): numeric score for how good the match is
+                higher is better, can be normalized to len(month)
+    """
+    # returns a tuple (best match, match score)
+    if match := check_dels(word, typ_dict):
+        # print('returning from dels')
+        return (match, len(match))
+    else:
+        # print('returning from misspells')
+        return check_misspells(word)
+
+
 def parse_long_dates(date_string):
     """Extracts three simple strings representing the year, month, and day 
     from a date in the  in the long format like 'November 19, 2010'.


### PR DESCRIPTION
Added six functions to add misspelling support to the month parsing. Use `pick_best_month` to get the best match (and a score associated with said match). 

- `check_dels` checks a month string to see if it matches a single-letter deletion
- `sliding_window` "slides" the target string across the misspelled month string to find the best match
- `score_window` helper function for `sliding_window`
- `check_misspells` checks the month string with `sliding_window` to find the best match
- `make_typo_dict` pulls the creation of a single-letter deletion dictionary out of my old function and into it's own function
- `pick_best_month` a wrapper function that tries the different spell-checking methods to determine the most likely month that was misspelled

We still need(?) tests to confirm to everyone, but I tested the misspelling detection using every possible single-letter misspelling and it works on all but two.
- "juny"
- "jule"

These two fail because they are both one change away from being either "june" or "july" and there's no way to determine which it is without additional context (which would be way more work).