### PR TITLE
Issue 36 get year links test

### DIFF
--- a/tests/data/pdf_download_data.py
+++ b/tests/data/pdf_download_data.py
@@ -5,15 +5,15 @@ from .sample_boe_page import HTML_TEXT
 SAMPLE_HTML = HTML_TEXT
 
 # Example set of expected year links pulled from HTML_TEXT
-YEAR_LINKS = ['<a href="/minutes-2020">2020</a>',
-              '<a href="/2019">2019</a>',
-              '<a href="/minutes-2018">2018</a>',
-              '<a href="/boe/meetings/minutes">2017</a>',
-              '<a href="/minutes-2016-0">2016</a>',
-              '<a href="/minutes-2015">2015</a>',
-              '<a href="/minutes-2014">2014</a>',
-              '<a href="/minutes-2013">2013</a>',
-              '<a href="/minutes-2012">2012</a>',
-              '<a href="/minutes-2011">2011</a>',
-              '<a href="/minutes-2010">2010</a>',
-              '<a href="/minutes-2009">2009</a>']
+YEAR_LINKS = {'2020': '/minutes-2020',
+              '2019': '/2019',
+              '2018': '/minutes-2018',
+              '2017': '/boe/meetings/minutes',
+              '2016': '/minutes-2016-0',
+              '2015': '/minutes-2015',
+              '2014': '/minutes-2014',
+              '2013': '/minutes-2013',
+              '2012': '/minutes-2012',
+              '2011': '/minutes-2011',
+              '2010': '/minutes-2010',
+              '2009': '/minutes-2009',}

--- a/tests/test_pdf_download.py
+++ b/tests/test_pdf_download.py
@@ -6,6 +6,7 @@ from pprint import pprint
 from .data.pdf_download_data import HTML_TEXT, YEAR_LINKS
 
 from bike_rack.check_page_setup import check_and_parse_page
+from utils import get_year_links
 
 
 class TestCheckAndParsePage:
@@ -52,18 +53,22 @@ class TestGetYearLinks:
     def test_get_year_links(self):
         """Tests the function that retrieves the list of links for each page
         on the Comptroller website that corresponds to a year of BOE meetings
-
-        TEST DATA
-        - A sample of the html scraped from a particular page
-        - A known list of year links from the BOE page
-
-        TEST SETUP
-        - N/A
-
-        ASSERTIONS
-        - assert that the scraped links matches the list of known links
         """
-        assert 1
+        # parses sample html for input to get_year_links() function
+        soup = BeautifulSoup(HTML_TEXT, 'html.parser')
+        expected = YEAR_LINKS
+
+        # runs get_year_links() function and captures output
+        output = get_year_links(soup)
+
+        # checks that the output of get_year_links matches the
+        # expected list of annual links from the sample html
+        print('EXPECTED')
+        pprint(expected)
+        print('OUTPUT')
+        pprint(output)
+        assert output == expected
+
 
     def test_exclude_non_year_links(self):
         """Tests the exclusion of other anchor tags on the page that match a

--- a/tests/test_pdf_download.py
+++ b/tests/test_pdf_download.py
@@ -70,25 +70,6 @@ class TestGetYearLinks:
         assert output == expected
 
 
-    def test_exclude_non_year_links(self):
-        """Tests the exclusion of other anchor tags on the page that match a
-        format similar to that of the links for each year of minutes
-
-        TEST DATA
-        - A sample of the html scraped from a particular page
-        - A list of anchor tags for each year in the sample html
-
-        TEST SETUP
-        - Add an anchor tag that matches the format of the year link to some
-          part of the sample HTML data outside the div where year links are
-          currently found
-
-        ASSERTIONS
-        - assert that the scraped links exclude the anchor tag added during
-          the test setup
-        """
-        assert 1
-
 class TestGetMeetingLinks:
     """Tests get_meeting_links() which retrieves all of the meeting links
     from the page that lists the BOE minutes for a given year


### PR DESCRIPTION
### Changes
- Adds `test_get_year_links()` which tests `get_year_links()` against a static sample of html scraped from https://comptroller.baltimorecity.gov/boe/meetings/minutes

### Instructions for review
- Checkout the pull request locally
- Run the tests by entering `pytest` into the command line prompt
- All tests should pass
- To inspect the test implementation look at `tests/test_pdf_download.py` 